### PR TITLE
Prepare second 1.0.0 release candidate

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spina-conferences-primer_theme-fork (1.0.0.rc1)
+    spina-conferences-primer_theme-fork (1.0.0.rc2)
       babel-transpiler (~> 0.7)
       cssbundling-rails (~> 1.0)
       icalendar (~> 2.5)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Or install it yourself as:
 $ gem install spina-conferences-primer_theme-fork
 ```
 
+The first thing you will probably want to do is add three pages using the 'blank' template, and add
+forwarding URLs as follows:
+* Conferences to `/conferences/conferences`
+* Journal to `/journal/issues`
+* Blog to `/blog`
+
 ## Contributing
 Contributions welcome, open an issue first please.
 

--- a/app/controllers/spina/conferences/primer_theme/conferences/application_controller.rb
+++ b/app/controllers/spina/conferences/primer_theme/conferences/application_controller.rb
@@ -6,8 +6,25 @@ module Spina
       module Conferences
         # Base class from which controllers inherit
         class ApplicationController < Spina::ApplicationController
+          before_action :journal_accessible?
+
           def cookies_info
             render partial: 'cookies'
+          end
+
+          private
+
+          def page
+            @page ||= Spina::Page.find_or_create_by name: 'conferences' do |page|
+              page.title = 'Conferences'
+              page.link_url = '/conferences/conferences'
+              page.deletable = false
+              page.view_template = 'blank'
+            end
+          end
+
+          def journal_accessible?
+            raise ActiveRecord::RecordNotFound unless current_spina_user.present? || page.live?
           end
         end
       end

--- a/app/controllers/spina/conferences/primer_theme/journal/application_controller.rb
+++ b/app/controllers/spina/conferences/primer_theme/journal/application_controller.rb
@@ -6,6 +6,22 @@ module Spina
       module Journal
         # Base class from which controllers related to the journal plugin inherit
         class ApplicationController < Spina::ApplicationController
+          before_action :journal_accessible?
+
+          private
+
+          def page
+            @page ||= Spina::Page.find_or_create_by name: 'journal' do |page|
+              page.title = 'Journal'
+              page.link_url = '/journal/issues'
+              page.deletable = false
+              page.view_template = 'blank'
+            end
+          end
+
+          def journal_accessible?
+            raise ActiveRecord::RecordNotFound unless current_spina_user.present? || page.live?
+          end
         end
       end
     end

--- a/app/controllers/spina/conferences/primer_theme/journal/articles_controller.rb
+++ b/app/controllers/spina/conferences/primer_theme/journal/articles_controller.rb
@@ -6,8 +6,8 @@ module Spina
       module Journal
         # User-facing controller for journal articles
         class ArticlesController < ApplicationController
-          before_action :set_volume, :set_issue, :set_article, :set_journal, :set_licence, :set_breadcrumb, :set_metadata,
-                        :require_admin_for_invisible_article
+          before_action :set_volume, :set_issue, :set_article, :set_journal, :set_licence,
+                        :set_breadcrumb, :set_metadata, :require_admin_for_invisible_article
 
           def show
             respond_to do |format|

--- a/app/controllers/spina/conferences/primer_theme/journal/articles_controller.rb
+++ b/app/controllers/spina/conferences/primer_theme/journal/articles_controller.rb
@@ -47,8 +47,8 @@ module Spina
           def set_breadcrumb
             return if @issue.blank?
 
-            add_breadcrumb @journal.name, frontend_issues_path
-            add_breadcrumb Admin::Journal::Issue.model_name.human.pluralize, frontend_issues_path
+            add_breadcrumb helpers.journal_abbreviation_or_name(@journal), frontend_issues_path
+            # add_breadcrumb Admin::Journal::Issue.model_name.human.pluralize, frontend_issues_path
             add_breadcrumb t('spina.conferences.primer_theme.journal.volume_issue', volume_number: @issue.volume.number,
                                                                                     issue_number: @issue.number),
                            frontend_issue_path(@issue.id)

--- a/app/controllers/spina/conferences/primer_theme/journal/authors_controller.rb
+++ b/app/controllers/spina/conferences/primer_theme/journal/authors_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Spina
+  module Conferences
+    module PrimerTheme
+      module Journal
+        # User-facing controller for authors
+        class AuthorsController < ApplicationController
+          before_action :set_journal, :set_breadcrumb
+          before_action :set_author, only: :show
+          before_action :set_metadata
+
+          def index
+            @authors = Admin::Journal::Author.all.sort do |a, b|
+              a.primary_affiliation.name <=> b.primary_affiliation.name
+            end
+          end
+
+          def show
+            add_breadcrumb @author.primary_affiliation.name
+          end
+
+          private
+
+          def set_journal
+            @journal = Admin::Journal::Journal.instance
+          end
+
+          def set_author
+            @author = Admin::Journal::Author.includes(:affiliations, :articles).find(params[:id])
+          rescue ActiveRecord::RecordNotFound
+            send_file Rails.root.join('public/404.html'), type: 'text/html; charset=utf-8', status: 404
+          end
+
+          def set_metadata
+            @title = @journal.name
+            @description = ActionView::Base.full_sanitizer.sanitize(@journal.content(:description))
+          end
+
+          def set_breadcrumb
+            add_breadcrumb helpers.journal_abbreviation_or_name(@journal), frontend_issues_path
+            add_breadcrumb Admin::Journal::Author.model_name.human(count: :many), frontend_authors_path
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spina/conferences/primer_theme/journal/issues_controller.rb
+++ b/app/controllers/spina/conferences/primer_theme/journal/issues_controller.rb
@@ -7,7 +7,7 @@ module Spina
         # User-facing controller for journal issues
         class IssuesController < ApplicationController
           before_action :set_journal
-          before_action :set_volume, :set_issue, :set_breadcrumb, only: :show
+          before_action :set_volume, :set_issue, only: :show
           before_action :set_metadata
 
           def index

--- a/app/controllers/spina/conferences/primer_theme/journal/issues_controller.rb
+++ b/app/controllers/spina/conferences/primer_theme/journal/issues_controller.rb
@@ -39,8 +39,8 @@ module Spina
           end
 
           def set_breadcrumb
-            add_breadcrumb @journal.name, frontend_issues_path
-            add_breadcrumb Admin::Journal::Issue.model_name.human.pluralize, frontend_issues_path
+            add_breadcrumb helpers.journal_abbreviation_or_name(@journal), frontend_issues_path
+            # add_breadcrumb Admin::Journal::Issue.model_name.human.pluralize, frontend_issues_path
           end
 
           def set_metadata

--- a/app/controllers/spina/conferences/primer_theme/journal/issues_controller.rb
+++ b/app/controllers/spina/conferences/primer_theme/journal/issues_controller.rb
@@ -7,7 +7,7 @@ module Spina
         # User-facing controller for journal issues
         class IssuesController < ApplicationController
           before_action :set_journal
-          before_action :set_issue, :set_breadcrumb, only: :show
+          before_action :set_volume, :set_issue, :set_breadcrumb, only: :show
           before_action :set_metadata
 
           def index
@@ -33,7 +33,13 @@ module Spina
           end
 
           def set_issue
-            @issue = Admin::Journal::Issue.includes(:volume, :articles).find(params[:id])
+            @issue = @volume.issues.includes(:volume, :articles).find_by!(number: params[:number])
+          rescue ActiveRecord::RecordNotFound
+            send_file Rails.root.join('public/404.html'), type: 'text/html; charset=utf-8', status: 404
+          end
+
+          def set_volume
+            @volume = Admin::Journal::Volume.includes(:issues).find_by!(number: params[:volume_number])
           rescue ActiveRecord::RecordNotFound
             send_file Rails.root.join('public/404.html'), type: 'text/html; charset=utf-8', status: 404
           end

--- a/app/helpers/spina/conferences/primer_theme/application_helper.rb
+++ b/app/helpers/spina/conferences/primer_theme/application_helper.rb
@@ -13,7 +13,7 @@ module Spina
         end
 
         def journal_abbreviation_or_name(journal)
-          journal.content(:journal_abbreviation).empty? ? journal.name : journal.content(:journal_abbreviation)
+          journal.content(:journal_abbreviation)&.empty? ? journal.name : journal.content(:journal_abbreviation)
         end
 
         def ancestors # rubocop:disable Metrics/AbcSize,Metrics/MethodLength

--- a/app/helpers/spina/conferences/primer_theme/application_helper.rb
+++ b/app/helpers/spina/conferences/primer_theme/application_helper.rb
@@ -13,7 +13,7 @@ module Spina
         end
 
         def journal_abbreviation_or_name(journal)
-          journal.content(:journal_abbreviation)&.empty? ? journal.name : journal.content(:journal_abbreviation)
+          journal.content(:journal_abbreviation) && journal.content(:journal_abbreviation).empty? ? journal.name : journal.content(:journal_abbreviation) # rubocop:disable Layout/LineLength
         end
 
         def ancestors # rubocop:disable Metrics/AbcSize,Metrics/MethodLength

--- a/app/helpers/spina/conferences/primer_theme/application_helper.rb
+++ b/app/helpers/spina/conferences/primer_theme/application_helper.rb
@@ -12,10 +12,19 @@ module Spina
           Spina::Admin::Conferences::Conference.order(dates: :asc).find_by('upper(dates) >= ?', Time.zone.today)
         end
 
+        def journal_abbreviation_or_name(journal)
+          journal.content(:journal_abbreviation).empty? ? journal.name : journal.content(:journal_abbreviation)
+        end
+
         def ancestors
           return [] if current_page.blank?
 
           render Primer::Beta::Breadcrumbs.new(mb: 4) do |component|
+            if current_page.resource&.name = 'journal'
+              component.item(href: frontend_issues_path) do
+                journal_abbreviation_or_name(Spina::Admin::Journal::Journal.instance)
+              end
+            end
             current_page.ancestors.each do |ancestor|
               component.item(href: ancestor.materialized_path) { ancestor.menu_title }
             end

--- a/app/helpers/spina/conferences/primer_theme/application_helper.rb
+++ b/app/helpers/spina/conferences/primer_theme/application_helper.rb
@@ -16,7 +16,7 @@ module Spina
           journal.content(:journal_abbreviation).empty? ? journal.name : journal.content(:journal_abbreviation)
         end
 
-        def ancestors
+        def ancestors # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
           return [] if current_page.blank?
 
           render Primer::Beta::Breadcrumbs.new(mb: 4) do |component|

--- a/app/helpers/spina/conferences/primer_theme/navigations_helper.rb
+++ b/app/helpers/spina/conferences/primer_theme/navigations_helper.rb
@@ -13,12 +13,20 @@ module Spina
           @footer_navigation_items ||= live_navigation_items('footer')
         end
 
+        def journal_navigation_items
+          @journal_navigation_items ||= live_resource_navigation_items('journal')
+        end
+
         private
 
         def live_navigation_items(name)
           ::Spina::NavigationItem.joins(:navigation)
                                  .where(spina_navigations: { name: name })
                                  .roots.regular_pages.in_menu.live.sorted
+        end
+
+        def live_resource_navigation_items(name)
+          ::Spina::Resource.find_by(name: name).pages.roots.in_menu.live.sorted
         end
       end
     end

--- a/app/helpers/spina/conferences/primer_theme/navigations_helper.rb
+++ b/app/helpers/spina/conferences/primer_theme/navigations_helper.rb
@@ -26,7 +26,7 @@ module Spina
         end
 
         def live_resource_navigation_items(name)
-          ::Spina::Resource.find_by(name: name).pages.roots.in_menu.live.sorted
+          ::Spina::Resource.find_by(name: name)&.pages&.roots&.in_menu&.live&.sorted || []
         end
       end
     end

--- a/app/views/conferences_primer_theme/pages/about.html.haml
+++ b/app/views/conferences_primer_theme/pages/about.html.haml
@@ -13,8 +13,8 @@
       = render Primer::SubheadComponent.new do |component|
         = component.heading { t :'.constitution.title' }
       - if content(:constitution).present?
-        = render Primer::FlexComponent.new(align_items: :center, py: 1) do
-          = render Primer::FlexItemComponent.new(flex_auto: true, pr: 1) do
+        = render Primer::BoxComponent.new(display: :flex, align_items: :center, py: 1) do
+          = render Primer::BoxComponent.new(flex: :auto, pr: 1) do
             = t :'.constitution.uploaded',
                 date: l(Spina::Attachment.find(content(:constitution).attachment_id).created_at.to_date, format: :long)
           = render Primer::ButtonComponent.new(tag: :a, href: content.attachment_url(:constitution), ml: 2, download: '') do
@@ -30,7 +30,7 @@
         %ul
           - repeater :minutes do |minutes_entry|
             %li.list-style-none.py-1.d-flex.flex-items-center
-              = render Primer::FlexItemComponent.new(flex_auto: true) do
+              = render Primer::BoxComponent.new(flex: :auto) do
                 - if minutes_entry.content(:date).present?
                   = t(:'.minutes.minutes_for_html', date: time_tag(minutes_entry.content(:date)))
                 - else
@@ -66,10 +66,10 @@
     %ul
       - repeater :partner_societies do |partner_society|
         %li.list-style-none.py-4.border-bottom
-          = render Primer::FlexComponent.new(direction: [:column, nil, :row_reverse, nil], align_items: :start) do
+          = render Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row_reverse, nil], align_items: :flex_start) do
             = render Primer::BaseComponent.new(tag: :div, flex: :auto) do
               = render Primer::HeadingComponent.new(tag: :h3, mb: 1) do
-                = render Primer::FlexComponent.new(flex_wrap: true, justify_content: :space_between) do
+                = render Primer::BoxComponent.new(display: :flex, flex_wrap: :wrap, justify_content: :space_between) do
                   - if partner_society.content(:name).present?
                     = render(Primer::Beta::Text.new(tag: :div)) { partner_society.content(:name) }
                   = render Primer::ButtonGroup.new(aria: { label: t(:'.partner_societies.contact_buttons') }) do |component|

--- a/app/views/conferences_primer_theme/pages/committee.html.haml
+++ b/app/views/conferences_primer_theme/pages/committee.html.haml
@@ -8,7 +8,7 @@
     %ul.mt-4
       - repeater(:committee_bios) do |committee_bio|
         %li.list-style-none.py-4.border-bottom
-          = render Primer::FlexComponent.new(direction: [:column, nil, :row, nil], align_items: :start) do
+          = render Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil], align_items: :flex_start) do
             - if committee_bio.content(:profile_picture).present?
               -# TODO: create helper to replace this, because Primer::Beta::Avatar limits size to 80 sadly
               %img.avatar.circle.mr-md-3.mb-3.mb-md-0.flex-shrink-0{src: committee_bio.content.image_url(:profile_picture, resize_to_fill: [150, 150]),
@@ -16,8 +16,8 @@
                                                                                           variant: { resize_to_fill: [150, 150] }),
                                                                     draggable: false,
                                                                     alt: committee_bio.content(:profile_picture).alt}
-            = render Primer::FlexItemComponent.new(flex_auto: true) do
-              = render Primer::FlexComponent.new(direction: [:column, nil, :row, nil], mb: 1) do
+            = render Primer::BoxComponent.new(flex: :auto) do
+              = render Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil], mb: 1) do
                 = render Primer::BoxComponent.new do
                   - if committee_bio.content(:name).present?
                     = render(Primer::HeadingComponent.new(tag: :h3)) do

--- a/app/views/conferences_primer_theme/pages/journal_information.html.haml
+++ b/app/views/conferences_primer_theme/pages/journal_information.html.haml
@@ -1,0 +1,10 @@
+- cache [current_page, journal_navigation_items] do
+  = render Primer::BoxComponent.new(display: :flex, direction: [:column, nil, nil, :row]) do
+    - cache current_page do
+      = render Primer::BoxComponent.new(col: 9) do
+        = render(Primer::HeadingComponent.new(tag: :h1)) { current_page.title }
+
+        - if content(:text).present?
+          = render(Primer::Markdown.new(mt: 4)) { content.html(:text).to_s }
+
+    = render 'journal_navigation'

--- a/app/views/conferences_primer_theme/pages/journal_information.html.haml
+++ b/app/views/conferences_primer_theme/pages/journal_information.html.haml
@@ -1,7 +1,7 @@
 - cache [current_page, journal_navigation_items] do
   = render Primer::BoxComponent.new(display: :flex, direction: [:column, nil, nil, :row]) do
     - cache current_page do
-      = render Primer::BoxComponent.new(col: 9) do
+      = render Primer::BoxComponent.new(col: [nil, nil, nil, 9]) do
         = render(Primer::HeadingComponent.new(tag: :h1)) { current_page.title }
 
         - if content(:text).present?

--- a/app/views/conferences_primer_theme/pages/periodical.html.haml
+++ b/app/views/conferences_primer_theme/pages/periodical.html.haml
@@ -8,16 +8,16 @@
     %ul.mt-4
       - repeater(:periodical_issues) do |issue|
         %li.list-style-none.py-4.border-bottom
-          = render Primer::FlexComponent.new(direction: [:column, nil, :row, nil], align_items: :start) do
+          = render Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil], align_items: :flex_start) do
             - if issue.content(:cover_img).present?
-              = render Primer::FlexItemComponent.new(mr: [nil, nil, 3, nil], mb: [3, nil, 0, nil], flex_shrink: 0) do
+              = render Primer::BoxComponent.new(mr: [nil, nil, 3, nil], mb: [3, nil, 0, nil], flex_shrink: 0) do
                 = render Primer::LinkComponent.new(href: issue.content(:url)) do
                   = image_tag(issue.content.image_url(:cover_img, resize_to_limit: [300, 300]),
                               srcset: srcset_string(issue.content(:cover_img),
                                                     variant: { resize_to_limit: [300, 300] }),
                               alt: issue.content(:cover_img).alt)
-            = render Primer::FlexItemComponent.new(flex_auto: true) do
-              = render Primer::FlexComponent.new(direction: [:column, nil, :row, nil], mb: 1) do
+            = render Primer::BoxComponent.new(flex: :auto) do
+              = render Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil], mb: 1) do
                 = render Primer::BoxComponent.new do
                   - if issue.content(:name).present?
                     = render Primer::HeadingComponent.new(tag: :h2) do
@@ -28,7 +28,7 @@
               - if issue.content(:description).present?
                 = render Primer::Markdown.new(tag: :div, color: :muted) do
                   = issue.content.html(:description).to_s
-              = render Primer::FlexComponent.new(direction: [:column, nil, :row, nil], align_items: :start) do
+              = render Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil], align_items: :flex_start) do
                 - if issue.content(:url).present?
                   = render Primer::ButtonComponent.new(scheme: :primary, tag: :a, href: issue.content(:url), mt: 2, mr: 2) do
                     = render Primer::OcticonComponent.new('link-external')

--- a/app/views/conferences_primer_theme/partials/_event.html.haml
+++ b/app/views/conferences_primer_theme/partials/_event.html.haml
@@ -1,5 +1,5 @@
 %li.list-style-none.py-4.border-bottom
-  = render Primer::FlexComponent.new(direction: :column, align_items: :start) do
+  = render Primer::BoxComponent.new(display: :flex, direction: :column, align_items: :flex_start) do
     - if event.content(:name).present?
       = render(Primer::HeadingComponent.new(tag: :h3, flex: :auto)) { event.content(:name) }
     = render Primer::HeadingComponent.new(tag: :h4, flex: :auto) do

--- a/app/views/layouts/conferences_primer_theme/application.html.haml
+++ b/app/views/layouts/conferences_primer_theme/application.html.haml
@@ -1,5 +1,5 @@
 - content_for :breadcrumbs do
-  - if current_page.ancestors.any?
+  - if current_page.ancestors.any? || current_page.resource&.name == 'journal'
     = ancestors
 
 = render template: 'layouts/spina/conferences/primer_theme/application',

--- a/app/views/layouts/spina/conferences/primer_theme/journal/articles.html.haml
+++ b/app/views/layouts/spina/conferences/primer_theme/journal/articles.html.haml
@@ -1,2 +1,5 @@
+- content_for :breadcrumbs do
+  = render_breadcrumbs(builder: Spina::Conferences::PrimerTheme::Breadcrumbs::Builder)
+
 = render template: 'layouts/spina/conferences/primer_theme/application',
          locals: { author: current_account.name, description: @description, title: @title, seo_title: @title, hide_alert: false }

--- a/app/views/layouts/spina/conferences/primer_theme/journal/authors.html.haml
+++ b/app/views/layouts/spina/conferences/primer_theme/journal/authors.html.haml
@@ -1,0 +1,5 @@
+- content_for :breadcrumbs do
+  = render_breadcrumbs(builder: Spina::Conferences::PrimerTheme::Breadcrumbs::Builder)
+
+= render template: 'layouts/spina/conferences/primer_theme/application',
+         locals: { author: current_account.name, description: @description, title: @title, seo_title: @title, hide_alert: false }

--- a/app/views/layouts/spina/conferences/primer_theme/journal/issues.html.haml
+++ b/app/views/layouts/spina/conferences/primer_theme/journal/issues.html.haml
@@ -1,2 +1,5 @@
+- content_for :breadcrumbs do
+  = render_breadcrumbs(builder: Spina::Conferences::PrimerTheme::Breadcrumbs::Builder)
+
 = render template: 'layouts/spina/conferences/primer_theme/application',
          locals: { author: current_account.name, description: @description, title: @title, seo_title: @title, hide_alert: false }

--- a/app/views/spina/application/_journal_navigation.html.haml
+++ b/app/views/spina/application/_journal_navigation.html.haml
@@ -3,9 +3,10 @@
     - component.heading(tag: :h2) do
       = Spina::Admin::Journal::Journal.instance.name
 
-    - component.item(selected: controller_name == 'issues',
-                     href: frontend_issues_path) do
+    - component.item(selected: controller_name == 'issues', href: frontend_issues_path) do
       = t '.issues'
+    - component.item(selected: controller_name == 'authors', href: frontend_authors_path) do
+      = t '.authors'
 
     - journal_navigation_items.each do |page|
       - component.item(selected: page == current_page, href: page.materialized_path) do

--- a/app/views/spina/application/_journal_navigation.html.haml
+++ b/app/views/spina/application/_journal_navigation.html.haml
@@ -1,0 +1,16 @@
+- cache [current_page, journal_navigation_items] do
+  = render Primer::MenuComponent.new(ml: [0, nil, nil, 4], mt: [4, 0, nil, nil], col: [nil, nil, nil, 3]) do |component|
+    - component.heading(tag: :h2) do
+      = Spina::Admin::Journal::Journal.instance.name
+
+    - component.item(selected: controller_name == 'issues',
+                     href: frontend_issues_path) do
+      = t '.issues'
+
+    - journal_navigation_items.each do |page|
+      - component.item(selected: page == current_page, href: page.materialized_path) do
+        = page.menu_title
+      - if page.children&.in_menu.live.any?
+        - page.children.in_menu.live.sorted.each do |sub_page|
+          - component.item(selected: sub_page == current_page, href: sub_page.materialized_path, pl: 5) do
+            = sub_page.menu_title

--- a/app/views/spina/application/_mobile_navigation_items.html.haml
+++ b/app/views/spina/application/_mobile_navigation_items.html.haml
@@ -1,5 +1,2 @@
 %nav.d-flex.flex-column.flex-self-stretch
   = render partial: 'mobile_navigation_item', collection: main_navigation_items, as: :navigation_item, cache: -> navigation_item { [navigation_item, navigation_item.children] }
-  .Header-item.mr-0.border-top.border-white-fade-15= link_to 'Blog', frontend_blog_root_path, class: %w[Header-link py-2 py-lg-0]
-  .Header-item.mr-0.border-top.border-white-fade-15= link_to 'Journal', frontend_issues_path, class: %w[Header-link py-2 py-lg-0]
-  .Header-item.mr-0.border-top.border-white-fade-15= link_to 'Conferences', frontend_conferences_path, class: %w[Header-link py-2 py-lg-0]

--- a/app/views/spina/application/_navigation.html.haml
+++ b/app/views/spina/application/_navigation.html.haml
@@ -7,6 +7,3 @@
       .Header-item.Header-item--full.flex-column.width-full.flex-order-1.mr-0.mt-3
         = render partial: 'mobile_navigation_items'
     = render partial: 'navigation_item', collection: main_navigation_items, cache: -> navigation_item { [navigation_item, navigation_item.children] }
-    .Header-item.d-none.d-lg-flex= link_to 'Blog', frontend_blog_root_path, class: %w[Header-link]
-    .Header-item.d-none.d-lg-flex= link_to 'Journal', frontend_issues_path, class: %w[Header-link]
-    .Header-item.d-none.d-lg-flex= link_to 'Conferences', frontend_conferences_path, class: %w[Header-link]

--- a/app/views/spina/conferences/primer_theme/blog/categories/show.html.haml
+++ b/app/views/spina/conferences/primer_theme/blog/categories/show.html.haml
@@ -3,8 +3,8 @@
 = render(Primer::HeadingComponent.new(tag: :h2)) do
   = t '.category', name: @category.name
 
-= render(Primer::FlexComponent.new(flex: :auto, direction: [:column, nil, :row, nil])) do
-  = render(Primer::FlexItemComponent.new(flex_auto: true)) do
+= render(Primer::BoxComponent.new(display: :flex, flex: :auto, direction: [:column, nil, :row, nil])) do
+  = render(Primer::BoxComponent.new(flex: :auto)) do
     - if @posts.any?
       %ul= render collection: @posts, partial: 'spina/conferences/primer_theme/blog/posts/post', layout: 'list_item', cached: true
     - else

--- a/app/views/spina/conferences/primer_theme/blog/posts/index.html.haml
+++ b/app/views/spina/conferences/primer_theme/blog/posts/index.html.haml
@@ -1,8 +1,8 @@
 = render(Primer::HeadingComponent.new(tag: :h1)) do
   Blog
 
-= render(Primer::FlexComponent.new(flex: :auto, direction: [:column, nil, :row, nil])) do
-  = render(Primer::FlexItemComponent.new(flex_auto: true)) do
+= render(Primer::BoxComponent.new(display: :flex, flex: :auto, direction: [:column, nil, :row, nil])) do
+  = render(Primer::BoxComponent.new(flex: :auto)) do
     - if @posts.any?
       %ul= render collection: @posts, partial: 'post', layout: 'list_item', cached: true
     - else

--- a/app/views/spina/conferences/primer_theme/blog/posts/show.html.haml
+++ b/app/views/spina/conferences/primer_theme/blog/posts/show.html.haml
@@ -2,16 +2,16 @@
   = @post.title
 
 %ul.list-style-none.d-flex.flex-column.flex-sm-row.my-2
-  = render(Primer::FlexComponent.new(tag: :li, mr: 4, align_items: :center)) do
-    = render(Primer::FlexItemComponent.new(mr: 2)) do
+  = render(Primer::BoxComponent.new(display: :flex, tag: :li, mr: 4, align_items: :center)) do
+    = render(Primer::BoxComponent.new(mr: 2)) do
       = render(Primer::OcticonComponent.new('person'))
-    = render(Primer::FlexComponent.new(tag: :address, direction: :column)) do
+    = render(Primer::BoxComponent.new(display: :flex, tag: :address, direction: :column)) do
       = render(Primer::Beta::Text.new(tag: :div, font_weight: :bold)) { @post.user.name }
 
 - if @post.image
   = image_tag main_app.url_for(@post.image.file)
 
-= render(Primer::FlexComponent.new(flex: :auto, direction: [:column, nil, :row, nil])) do
-  = render(Primer::FlexItemComponent.new(flex_auto: true)) do
+= render(Primer::BoxComponent.new(display: :flex, flex: :auto, direction: [:column, nil, :row, nil])) do
+  = render(Primer::BoxComponent.new(flex: :auto)) do
     = render(Primer::Markdown.new(tag: :article)) do
       = @post.content.html_safe

--- a/app/views/spina/conferences/primer_theme/conferences/conferences/_conference.html.haml
+++ b/app/views/spina/conferences/primer_theme/conferences/conferences/_conference.html.haml
@@ -1,7 +1,7 @@
-= render Primer::FlexComponent.new(direction: [:column, nil, :row_reverse, nil]) do
+= render Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row_reverse, nil]) do
   %ul.list-style-none.d-flex.flex-wrap.flex-md-justify-end.pl-md-2.pb-2.pb-md-0
     = render partial: 'institution', collection: conference.institutions, cached: -> institution { [institution, institution.logo] }
-  = render Primer::FlexItemComponent.new(flex_auto: true) do
+  = render Primer::BoxComponent.new(flex: :auto) do
     = render(Primer::HeadingComponent.new(tag: :h3, mb: 1)) { link_to conference.name, frontend_conference_path(conference) }
     %ul.text-secondary.list-style-none.d-flex.flex-column.flex-sm-row.flex-wrap
       %li.mr-sm-3

--- a/app/views/spina/conferences/primer_theme/conferences/conferences/_event.html.haml
+++ b/app/views/spina/conferences/primer_theme/conferences/conferences/_event.html.haml
@@ -1,12 +1,12 @@
-= render Primer::FlexComponent.new(direction: [:column, nil, :row, nil]) do
-  = render Primer::FlexItemComponent.new(mr: [nil, nil, 3, nil], mb: [3, nil, 0, nil], col: [nil, nil, 4, nil]) do
+= render Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil]) do
+  = render Primer::BoxComponent.new(mr: [nil, nil, 3, nil], mb: [3, nil, 0, nil], col: [nil, nil, 4, nil]) do
     = render Primer::Beta::Text.new(tag: :div, font_size: 3, font_weight: :light, mb: 1) do
       = render Primer::OcticonComponent.new('clock', vertical_align: :baseline)
       = t :'.times_html', start_time: time_tag(event.start_time, format: :short), finish_time: time_tag(event.finish_time, format: :time)
     = render Primer::Beta::Text.new(tag: :div, color: :muted) do
       = render Primer::OcticonComponent.new('location')
       = render(Primer::BaseComponent.new(tag: :address, display: :inline)) { event.location }
-  = render Primer::FlexItemComponent.new(flex_auto: true, col: [nil, nil, 8, nil]) do
+  = render Primer::BoxComponent.new(flex: :auto, col: [nil, nil, 8, nil]) do
     = render(Primer::HeadingComponent.new(tag: :h3, mb: 1)) { event.name }
     = render(Primer::Beta::Text.new(tag: :div, color: :muted)) do
       = event.description

--- a/app/views/spina/conferences/primer_theme/conferences/conferences/_header.html.haml
+++ b/app/views/spina/conferences/primer_theme/conferences/conferences/_header.html.haml
@@ -19,9 +19,9 @@
     - if @conference.content(:sponsors).present?
       = render Primer::SubheadComponent.new(spacious: true) do |component|
         = component.heading(tag: :h2) { t :'.sponsors.title' }
-      = render Primer::FlexComponent.new(flex_wrap: true, ml: -2, mr: -2, mt: -2, mb: -2) do
+      = render Primer::BoxComponent.new(display: :flex, flex_wrap: :wrap, ml: -2, mr: -2, mt: -2, mb: -2) do
         - repeater @conference.content(:sponsors) do |sponsor|
-          = render Primer::FlexItemComponent.new(m: 2, vertical_align: :middle) do
+          = render Primer::BoxComponent.new(m: 2, vertical_align: :middle) do
             - if sponsor.content(:logo).present?
               = link_to sponsor.content(:website) do
                 = sponsor.content.image_tag(:logo, { resize_to_limit: [200, 60] }, draggable: false,
@@ -30,7 +30,7 @@
               = render(Primer::LinkComponent.new(href: sponsor.content(:website) || '')) { sponsor.content(:name) }
 
   - if @conference.content(:gallery).present?
-    = render Primer::FlexComponent.new(flex_direction: :column, justify_content: :center, align_items: :center, mb: 4, position: :relative,
+    = render Primer::BoxComponent.new(display: :flex, flex_direction: :column, justify_content: :center, align_items: :center, mb: 4, position: :relative,
                                        data: { controller: :slideshow, slideshow_incrementer: 0, slideshow_advance: true }) do
       - @conference.content(:gallery).each_with_index do |image, index|
         = @conference.content.image_tag(image, { resize_to_fill: [1680, 600] }, draggable: false, data: { 'slideshow-target': 'slide' },

--- a/app/views/spina/conferences/primer_theme/conferences/conferences/_presentation.html.haml
+++ b/app/views/spina/conferences/primer_theme/conferences/conferences/_presentation.html.haml
@@ -1,4 +1,4 @@
-= render Primer::FlexComponent.new(direction: [:column, nil, :row, nil]) do
+= render Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil]) do
   = render Primer::BaseComponent.new(tag: :div, flex_shrink: 0, mr: [nil, nil, 3, nil], mb: [3, nil, 0, nil], col: [nil, nil, 3, nil]) do
     = render Primer::Beta::Text.new(tag: :div, font_size: 3, font_weight: :light, mb: 1) do
       = render Primer::OcticonComponent.new('clock', vertical_align: :baseline)

--- a/app/views/spina/conferences/primer_theme/conferences/conferences/_presentations.html.haml
+++ b/app/views/spina/conferences/primer_theme/conferences/conferences/_presentations.html.haml
@@ -1,6 +1,6 @@
 - cache [@conference.presentations, @presentation_type, @presentations, @presentations.collect(&:presenters), @tab] do
-  = render Primer::FlexComponent.new(direction: [:column, nil, nil, :row], my: 4) do
-    = render Primer::FlexItemComponent.new(pr: [nil, nil, nil, 4], mb: [4, nil, nil, 0], col: [12, nil, nil, 3]) do
+  = render Primer::BoxComponent.new(display: :flex, direction: [:column, nil, nil, :row], my: 4) do
+    = render Primer::BoxComponent.new(pr: [nil, nil, nil, 4], mb: [4, nil, nil, 0], col: [12, nil, nil, 3]) do
       %ul.filter-list
         - cache [@conference.presentations, @presentation_type] do
           %li
@@ -10,7 +10,7 @@
               %span.count{ title: t(:'.results') }= @conference.presentations.count
         = render partial: 'presentation_type', collection: @conference.presentation_types.sorted,
                  cached: -> presentation_type { [presentation_type, @presentation_type] }
-    = render Primer::FlexItemComponent.new(col: [12, nil, nil, 9]) do
+    = render Primer::BoxComponent.new(col: [12, nil, nil, 9]) do
       - if @presentations.any?
         %filter-input{ aria: { owns: 'presentation_list' } }
           .subnav.subnav-flush

--- a/app/views/spina/conferences/primer_theme/conferences/conferences/index.html.haml
+++ b/app/views/spina/conferences/primer_theme/conferences/conferences/index.html.haml
@@ -1,12 +1,12 @@
-= render Primer::FlexComponent.new(direction: [:column_reverse, nil, :row, nil]) do
-  = render Primer::FlexItemComponent.new(flex_auto: true, mb: [4, nil, 0, nil]) do
+= render Primer::BoxComponent.new(display: :flex, direction: [:column_reverse, nil, :row, nil]) do
+  = render Primer::BoxComponent.new(flex: :auto, mb: [4, nil, 0, nil]) do
     %filter-input{ aria: { owns: 'conference_list' } }
       - if @conferences.any?
         .subnav.subnav-flush
           .subnav-search.float-left.ml-0
             = search_field_tag 'search', nil, class: %w[form-control subnav-search-input], aria: { label: t(:'.search') }
             = render Primer::OcticonComponent.new('search', classes: 'subnav-search-icon')
-  = render Primer::FlexItemComponent.new(mb: [4, nil, 0, nil]) do
+  = render Primer::BoxComponent.new(mb: [4, nil, 0, nil]) do
     = render Primer::ButtonComponent.new(tag: :a, href: frontend_conferences_url(protocol: :webcal, format: :ics), button_type: :primary,
                                          ml: [0, nil, 6, nil]) do
       = render Primer::OcticonComponent.new('calendar')

--- a/app/views/spina/conferences/primer_theme/journal/articles/_authorship.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/articles/_authorship.html.haml
@@ -1,6 +1,6 @@
-= render(Primer::FlexComponent.new(tag: :li, mr: 4, align_items: :center)) do
-  = render(Primer::FlexItemComponent.new(mr: 2)) do
+= render(Primer::BoxComponent.new(display: :flex, tag: :li, mr: 4, align_items: :center)) do
+  = render(Primer::BoxComponent.new(mr: 2)) do
     = render(Primer::OcticonComponent.new('person'))
-  = render(Primer::FlexComponent.new(tag: :address, direction: :column)) do
+  = render(Primer::BoxComponent.new(display: :flex, tag: :address, direction: :column)) do
     = render(Primer::Beta::Text.new(tag: :div, font_weight: :bold)) { authorship.affiliation.name }
     = render(Primer::Beta::Text.new(tag: :div, color: :muted)) { authorship.affiliation.institution.name }

--- a/app/views/spina/conferences/primer_theme/journal/articles/_authorship.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/articles/_authorship.html.haml
@@ -1,6 +1,8 @@
-= render(Primer::BoxComponent.new(display: :flex, tag: :li, mr: 4, align_items: :center)) do
-  = render(Primer::BoxComponent.new(mr: 2)) do
-    = render(Primer::OcticonComponent.new('person'))
-  = render(Primer::BoxComponent.new(display: :flex, tag: :address, direction: :column)) do
-    = render(Primer::Beta::Text.new(tag: :div, font_weight: :bold)) { authorship.affiliation.name }
-    = render(Primer::Beta::Text.new(tag: :div, color: :muted)) { authorship.affiliation.institution.name }
+%li
+  = link_to frontend_author_path(authorship.affiliation.author) do
+    = render(Primer::BoxComponent.new(display: :flex, tag: :li, mr: 4, align_items: :center)) do
+      = render(Primer::BoxComponent.new(mr: 2)) do
+        = render(Primer::OcticonComponent.new('person'))
+      = render(Primer::BoxComponent.new(display: :flex, tag: :address, direction: :column)) do
+        = render(Primer::Beta::Text.new(tag: :div, font_weight: :bold)) { authorship.affiliation.name }
+        = render(Primer::Beta::Text.new(tag: :div, color: :muted)) { authorship.affiliation.institution.name }

--- a/app/views/spina/conferences/primer_theme/journal/articles/_metadata.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/articles/_metadata.html.haml
@@ -8,7 +8,7 @@
   - if @article.has_content? :attachment
     %meta{ name: 'DC.Format', scheme: 'IMT', content: 'application/pdf' }
   %meta{ name: 'DC.Identifier', content: @article.id }
-  %meta{ name: 'DC.Identifier.URI', content: frontend_issue_article_url(@issue.id, @article.id) }
+  %meta{ name: 'DC.Identifier.URI', content: frontend_volume_issue_article_url(@volume.number, @issue.number, @article.number) }
   - if @article.has_content? :page_range
     %meta{ name: 'DC.Identifier.pageNumber', content: "#{@article.content(:page_range).first_page}-#{@article.content(:page_range).last_page}" }
   %meta{ name: 'DC.Language', scheme: 'ISO639-1', content: 'en' }
@@ -37,5 +37,5 @@
   - if @article.has_content? :page_range
     %meta{ name: 'citation_firstpage', content: @article.content(:page_range).first_page }
     %meta{ name: 'citation_lastpage', content: @article.content(:page_range).last_page }
-  %meta{ name: 'citation_abstract_html_url', content: frontend_issue_article_url(@issue.id, @article.id) }
-  %meta{ name: 'citation_pdf_url', content: frontend_issue_article_url(@issue.id, @article.id) + '.pdf' }
+  %meta{ name: 'citation_abstract_html_url', content: frontend_volume_issue_article_url(@volume.number, @issue.number, @article.number) }
+  %meta{ name: 'citation_pdf_url', content: frontend_volume_issue_article_url(@volume.number, @issue.number, @article.number) + '.pdf' }

--- a/app/views/spina/conferences/primer_theme/journal/articles/show.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/articles/show.html.haml
@@ -16,7 +16,7 @@
 
       - if @article.has_content?(:abstract)
         = render(Primer::HeadingComponent.new(tag: :h2, mt: 4, font_size: 3)) { t '.abstract' }
-        = render(Primer::Markdown.new) { @article.content.html(:abstract) }
+        = render(Primer::Markdown.new) { @article.content.html(:abstract).to_s }
 
     = render(Primer::BorderBoxComponent.new(ml: [nil, nil, 4, nil], style: 'min-width: 20vw')) do |sidebar|
       - sidebar.body do

--- a/app/views/spina/conferences/primer_theme/journal/articles/show.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/articles/show.html.haml
@@ -6,13 +6,7 @@
   = render(Primer::BoxComponent.new(display: :flex, direction: [:column, nil, nil, :row])) do
     = render(Primer::BoxComponent.new(flex: :auto, mr: [nil, nil, nil, 4], col: [nil, nil, nil, 8])) do
       %ul.list-style-none.d-flex.flex-column.flex-sm-row.my-2
-        - @article.affiliations.each do |affiliation|
-          = render(Primer::BoxComponent.new(display: :flex, tag: :li, mr: 4, align_items: :center)) do
-            = render(Primer::BoxComponent.new(mr: 2)) do
-              = render(Primer::OcticonComponent.new('person'))
-            = render(Primer::BoxComponent.new(display: :flex, tag: :address, direction: :column)) do
-              = render(Primer::Beta::Text.new(tag: :div, font_weight: :bold)) { affiliation.name }
-              = render(Primer::Beta::Text.new(tag: :div, color: :muted)) { affiliation.institution.name }
+        = render partial: 'authorship', collection: @article.authorships.sorted_within_article
 
       - if @article.has_content?(:abstract)
         = render(Primer::HeadingComponent.new(tag: :h2, mt: 4, font_size: 3)) { t '.abstract' }

--- a/app/views/spina/conferences/primer_theme/journal/articles/show.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/articles/show.html.haml
@@ -25,7 +25,7 @@
         = render(Primer::BorderBoxComponent.new) do |component|
           - if @article.has_content?(:attachment)
             - component.row do
-              = render(Primer::ButtonComponent.new(tag: :a, href: frontend_issue_article_path(@issue, @article, format: :pdf), download: '', scheme: :primary)) do
+              = render(Primer::ButtonComponent.new(tag: :a, href: frontend_volume_issue_article_path(@issue.volume.number, @issue.number, @article.number, format: :pdf), download: '', scheme: :primary)) do
                 = render Primer::OcticonComponent.new('download')
                 = t '.download'
           - component.row do
@@ -37,7 +37,7 @@
             = render(Primer::Beta::Text.new) do
               = link_to t('spina.conferences.primer_theme.journal.volume_issue',
                           volume_number: @article.issue.volume.number,
-                          issue_number: @article.issue.number), frontend_issue_path(@article.issue)
+                          issue_number: @article.issue.number), frontend_volume_issue_path(@article.issue.volume.number, @article.issue.number)
           - unless @article.doi.blank?
             - component.row do
               = render(Primer::HeadingComponent.new(tag: :h2, font_size: 4, color: :muted)) { t '.doi' }
@@ -51,7 +51,7 @@
           - component.row do
             = render(Primer::HeadingComponent.new(tag: :h2, font_size: 4, color: :muted)) { t '.permalink' }
             = render(Primer::Beta::Text.new(tag: :div, color: :muted, mt: 1)) do
-              = link_to nil, frontend_issue_article_url(@issue, @article)
+              = link_to nil, frontend_volume_issue_article_url(@volume.number, @issue.number, @article.number)
           - component.row do
             = render(Primer::BoxComponent.new(display: :flex, direction: :column)) do
               = render(Primer::Beta::Text.new(mb: 2)) do

--- a/app/views/spina/conferences/primer_theme/journal/articles/show.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/articles/show.html.haml
@@ -3,8 +3,8 @@
 
   = render(Primer::HeadingComponent.new(tag: :h1)) { @article.title }
 
-  = render(Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil])) do
-    = render(Primer::BoxComponent.new(flex: :auto, mr: [nil, nil, 4, nil])) do
+  = render(Primer::BoxComponent.new(display: :flex, direction: [:column, nil, nil, :row])) do
+    = render(Primer::BoxComponent.new(flex: :auto, mr: [nil, nil, nil, 4], col: [nil, nil, nil, 8])) do
       %ul.list-style-none.d-flex.flex-column.flex-sm-row.my-2
         - @article.affiliations.each do |affiliation|
           = render(Primer::BoxComponent.new(display: :flex, tag: :li, mr: 4, align_items: :center)) do
@@ -18,7 +18,7 @@
         = render(Primer::HeadingComponent.new(tag: :h2, mt: 4, font_size: 3)) { t '.abstract' }
         = render(Primer::Markdown.new) { @article.content.html(:abstract).to_s }
 
-    = render(Primer::BorderBoxComponent.new(ml: [nil, nil, 4, nil], style: 'min-width: 20vw')) do |sidebar|
+    = render(Primer::BorderBoxComponent.new(ml: [nil, nil, nil, 4], col: [nil, nil, nil, 4])) do |sidebar|
       - sidebar.body do
         - if @article.issue.has_content?(:cover_img)
           = render partial: 'spina/conferences/primer_theme/journal/issues/issue_cover', locals: { issue: @article.issue, cover_img: @article.issue.content(:cover_img), size: [200, 400] }

--- a/app/views/spina/conferences/primer_theme/journal/articles/show.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/articles/show.html.haml
@@ -3,14 +3,14 @@
 
   = render(Primer::HeadingComponent.new(tag: :h1)) { @article.title }
 
-  = render(Primer::FlexComponent.new(direction: [:column, nil, :row, nil])) do
-    = render(Primer::FlexItemComponent.new(flex_auto: true, mr: [nil, nil, 4, nil])) do
+  = render(Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil])) do
+    = render(Primer::BoxComponent.new(flex: :auto, mr: [nil, nil, 4, nil])) do
       %ul.list-style-none.d-flex.flex-column.flex-sm-row.my-2
         - @article.affiliations.each do |affiliation|
-          = render(Primer::FlexComponent.new(tag: :li, mr: 4, align_items: :center)) do
-            = render(Primer::FlexItemComponent.new(mr: 2)) do
+          = render(Primer::BoxComponent.new(display: :flex, tag: :li, mr: 4, align_items: :center)) do
+            = render(Primer::BoxComponent.new(mr: 2)) do
               = render(Primer::OcticonComponent.new('person'))
-            = render(Primer::FlexComponent.new(tag: :address, direction: :column)) do
+            = render(Primer::BoxComponent.new(display: :flex, tag: :address, direction: :column)) do
               = render(Primer::Beta::Text.new(tag: :div, font_weight: :bold)) { affiliation.name }
               = render(Primer::Beta::Text.new(tag: :div, color: :muted)) { affiliation.institution.name }
 
@@ -49,7 +49,7 @@
               = render(Primer::Beta::Text.new(tag: :div, color: :muted, mt: 1)) do
                 = link_to nil, @article.url
           - component.row do
-            = render(Primer::FlexComponent.new(direction: :column)) do
+            = render(Primer::BoxComponent.new(display: :flex, direction: :column)) do
               = render(Primer::Beta::Text.new(mb: 2)) do
                 Copyright © #{@article.issue.date.year} #{@article.affiliations.collect(&:name).to_sentence}
               - unless @licence.nil?

--- a/app/views/spina/conferences/primer_theme/journal/articles/show.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/articles/show.html.haml
@@ -49,6 +49,10 @@
               = render(Primer::Beta::Text.new(tag: :div, color: :muted, mt: 1)) do
                 = link_to nil, @article.url
           - component.row do
+            = render(Primer::HeadingComponent.new(tag: :h2, font_size: 4, color: :muted)) { t '.permalink' }
+            = render(Primer::Beta::Text.new(tag: :div, color: :muted, mt: 1)) do
+              = link_to nil, frontend_issue_article_url(@issue, @article)
+          - component.row do
             = render(Primer::BoxComponent.new(display: :flex, direction: :column)) do
               = render(Primer::Beta::Text.new(mb: 2)) do
                 Copyright © #{@article.issue.date.year} #{@article.affiliations.collect(&:name).to_sentence}

--- a/app/views/spina/conferences/primer_theme/journal/authors/_author.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/authors/_author.html.haml
@@ -1,0 +1,9 @@
+= render(Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil], align_items: [:flex_start, nil, nil, :center])) do
+  = render(Primer::BoxComponent.new(mr: 2)) do
+    = render(Primer::OcticonComponent.new('person'))
+  = render(Primer::BoxComponent.new(flex: :auto)) do
+    = link_to frontend_author_path(author) do
+      = render(Primer::HeadingComponent.new(tag: :h3, mb: 1)) do
+        = author.primary_affiliation.name
+      = render(Primer::HeadingComponent.new(tag: :h4, color: :muted, mb: 1)) do
+        = author.primary_affiliation.institution.name

--- a/app/views/spina/conferences/primer_theme/journal/authors/index.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/authors/index.html.haml
@@ -1,0 +1,10 @@
+= render(Primer::BoxComponent.new(display: :flex, direction: [:column, nil, nil, :row])) do
+  = render(Primer::BoxComponent.new(col: [nil, nil, nil, 9])) do
+    = render(Primer::HeadingComponent.new(tag: :h1)) do
+      = @journal.name
+    = render(Primer::HeadingComponent.new(tag: :h2, mt: 3)) { t '.authors' }
+    - if @authors.any?
+      %ul= render partial: 'author', collection: @authors, layout: 'list_item', cached: true
+    - else
+      = render Primer::BlankslateComponent.new(title: t(:'.no_authors'), icon: 'mortar-board')
+  = render 'journal_navigation'

--- a/app/views/spina/conferences/primer_theme/journal/authors/show.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/authors/show.html.haml
@@ -1,0 +1,20 @@
+= render(Primer::BoxComponent.new(display: :flex, direction: [:column, nil, nil, :row])) do
+  = render(Primer::BoxComponent.new(col: [nil, nil, nil, 9])) do
+    = render(Primer::HeadingComponent.new(tag: :h1)) do
+      = @journal.name
+    = render(Primer::HeadingComponent.new(tag: :h2, mt: 2)) do
+      = t '.name_institution', name: @author.primary_affiliation.name, institution: @author.primary_affiliation.institution.name
+    - if @author.affiliations.count > 1
+      = render(Primer::BoxComponent.new) do
+        = render(Primer::Beta::Text.new) do
+          = t '.aka'
+          = @author.affiliations.not_primary.map { |affiliation| t('.name_institution', name: affiliation.name, institution: affiliation.institution.name) }.join(', ')
+
+    = render(Primer::HeadingComponent.new(tag: :h3, mt: 3)) { t '.articles' }
+
+    - if @author.articles.any?
+      %ul= render partial: 'spina/conferences/primer_theme/journal/issues/article', collection: @author.articles.sorted_asc, layout: 'list_item', cached: true
+    - else
+      = render Primer::BlankslateComponent.new(title: t(:'.no_articles'), icon: 'mortar-board')
+
+  = render 'journal_navigation'

--- a/app/views/spina/conferences/primer_theme/journal/issues/_article.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/_article.html.haml
@@ -1,5 +1,5 @@
-= render(Primer::FlexComponent.new(direction: [:column, nil, :row, nil])) do
-  = render(Primer::FlexItemComponent.new(flex_auto: true)) do
+= render(Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil])) do
+  = render(Primer::BoxComponent.new(flex: :auto)) do
     = render(Primer::HeadingComponent.new(tag: :h3, mb: 1)) do
       = link_to article.title, frontend_issue_article_path(article.issue, article)
     = render(Primer::Beta::Text.new(tag: :div, color: :muted)) do

--- a/app/views/spina/conferences/primer_theme/journal/issues/_article.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/_article.html.haml
@@ -1,7 +1,7 @@
 = render(Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil])) do
   = render(Primer::BoxComponent.new(flex: :auto)) do
     = render(Primer::HeadingComponent.new(tag: :h3, mb: 1)) do
-      = link_to article.title, frontend_issue_article_path(article.issue, article)
+      = link_to article.title, frontend_volume_issue_article_path(article.issue.volume.number, article.issue.number, article.number)
     = render(Primer::Beta::Text.new(tag: :div, color: :muted)) do
       = render(Primer::OcticonComponent.new(article.affiliations.many? ? 'people' : 'person'))
       = render(Primer::BaseComponent.new(tag: :address, display: :inline)) do
@@ -10,6 +10,6 @@
       = render(Primer::Beta::Text.new(tag: :div, color: :muted)) do
         = link_to nil, article.doi
     - if article.has_content?(:attachment)
-      = render(Primer::ButtonComponent.new(tag: :a, href: frontend_issue_article_path(article.issue, article, format: :pdf), mt: 2, download: '')) do
+      = render(Primer::ButtonComponent.new(tag: :a, href: frontend_volume_issue_article_path(article.issue.volume.number, article.issue.number, article.number, format: :pdf), mt: 2, download: '')) do
         = render Primer::OcticonComponent.new('download')
         = t '.download'

--- a/app/views/spina/conferences/primer_theme/journal/issues/_issue.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/_issue.html.haml
@@ -14,4 +14,4 @@
       = time_tag issue.date, format: :long
     - if issue.has_content?(:description)
       = render(Primer::Beta::Text.new(tag: :div, color: :muted, mt: 2)) do
-        = issue.content.html(:description)
+        = issue.content.html(:description).to_s

--- a/app/views/spina/conferences/primer_theme/journal/issues/_issue.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/_issue.html.haml
@@ -1,7 +1,7 @@
 = render(Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil])) do
   - if issue.content(:cover_img).present?
     = render(Primer::BoxComponent.new(mr: 4)) do
-      = link_to frontend_issue_path do
+      = link_to frontend_issue_path(issue) do
         = render partial: 'issue_cover', locals: { issue: issue, cover_img: issue.content(:cover_img), size: [150, 300] }
   = render(Primer::BoxComponent.new(flex: :auto)) do
     = render(Primer::HeadingComponent.new(tag: :h3, mb: 1)) do

--- a/app/views/spina/conferences/primer_theme/journal/issues/_issue.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/_issue.html.haml
@@ -1,8 +1,8 @@
-= render(Primer::FlexComponent.new(direction: [:column, nil, :row, nil])) do
+= render(Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil])) do
   - if issue.content(:cover_img).present?
-    = render(Primer::FlexItemComponent.new(mr: 4)) do
+    = render(Primer::BoxComponent.new(mr: 4)) do
       = render partial: 'issue_cover', locals: { issue: issue, cover_img: issue.content(:cover_img), size: [150, 300] }
-  = render(Primer::FlexItemComponent.new(flex_auto: true)) do
+  = render(Primer::BoxComponent.new(flex: :auto)) do
     = render(Primer::HeadingComponent.new(tag: :h3, mb: 1)) do
       = link_to t('spina.conferences.primer_theme.journal.volume_issue',
                   volume_number: issue.volume.number,

--- a/app/views/spina/conferences/primer_theme/journal/issues/_issue.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/_issue.html.haml
@@ -1,13 +1,13 @@
 = render(Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil])) do
   - if issue.content(:cover_img).present?
     = render(Primer::BoxComponent.new(mr: 4)) do
-      = link_to frontend_issue_path(issue) do
+      = link_to frontend_volume_issue_path(issue.volume.number, issue.number) do
         = render partial: 'issue_cover', locals: { issue: issue, cover_img: issue.content(:cover_img), size: [150, 300] }
   = render(Primer::BoxComponent.new(flex: :auto)) do
     = render(Primer::HeadingComponent.new(tag: :h3, mb: 1)) do
       = link_to t('spina.conferences.primer_theme.journal.volume_issue',
                   volume_number: issue.volume.number,
-                  issue_number: issue.number), frontend_issue_path(issue)
+                  issue_number: issue.number), frontend_volume_issue_path(issue.volume.number, issue.number)
     - unless issue.title.blank?
       = render(Primer::HeadingComponent.new(tag: :h4, color: :muted, mb: 1)) do
         = issue.title

--- a/app/views/spina/conferences/primer_theme/journal/issues/_issue.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/_issue.html.haml
@@ -1,7 +1,8 @@
 = render(Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil])) do
   - if issue.content(:cover_img).present?
     = render(Primer::BoxComponent.new(mr: 4)) do
-      = render partial: 'issue_cover', locals: { issue: issue, cover_img: issue.content(:cover_img), size: [150, 300] }
+      = link_to frontend_issue_path do
+        = render partial: 'issue_cover', locals: { issue: issue, cover_img: issue.content(:cover_img), size: [150, 300] }
   = render(Primer::BoxComponent.new(flex: :auto)) do
     = render(Primer::HeadingComponent.new(tag: :h3, mb: 1)) do
       = link_to t('spina.conferences.primer_theme.journal.volume_issue',

--- a/app/views/spina/conferences/primer_theme/journal/issues/index.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/index.html.haml
@@ -1,26 +1,25 @@
-= render(Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil])) do
-  = render(Primer::BoxComponent.new(display: :flex, direction: :column, flex: :auto)) do
-    = render(Primer::HeadingComponent.new(tag: :h1)) { @journal.name }
-    - if @journal.has_content? :description
-      = render(Primer::Markdown.new(my: 4)) { @journal.content.html(:description).to_s }
-  = render(Primer::BorderBoxComponent.new(ml: [nil, nil, 4, nil], style: 'min-width: 15vw;')) do |sidebar|
-    - if @journal.has_content? :logo
-      - sidebar.header(bg: :primary) do
-        = render(Primer::BoxComponent.new(mb: 4)) do
-          - cache @journal.content(:logo) do
-            = image_tag main_app.url_for(@journal.content(:logo).variant(resize_to_limit: [300, 150])),
-                        srcset: srcset(@journal.content(:logo), variant: { resize_to_limit: [300, 150] }),
-                        alt_description: t('.logo'),
-                        draggable: false,
-                        class: 'p-1'
-    - unless @latest_issue.nil?
-      - sidebar.row do
-        = render(Primer::HeadingComponent.new(tag: :h2, font_size: 3)) do
-          = link_to t('.latest_issue', volume_number: @latest_issue.volume.number, issue_number: @latest_issue.number), frontend_issue_path(@latest_issue)
-      - if @latest_issue.has_content?(:cover_img)
-        - sidebar.row do
-          = link_to(frontend_issue_path(@latest_issue)) do
-            = render partial: 'issue_cover', locals: { issue: @latest_issue, cover_img: @latest_issue.content(:cover_img), size: [150, 300] }
+= render(Primer::BoxComponent.new(display: :flex, direction: [:column, nil, nil, :row])) do
+  = render(Primer::BoxComponent.new(display: :flex, direction: :column, col: [nil, nil, nil, 9])) do
+    = render(Primer::BoxComponent.new) do
+      = render(Primer::HeadingComponent.new(tag: :h1)) { @journal.name }
+      - if @journal.has_content? :description
+        = render(Primer::Markdown.new(my: 4)) { @journal.content.html(:description).to_s }
+    = render Primer::BoxComponent.new(my: 4, col: [12, nil, 6, nil], float: [nil, nil, :left, nil]) do
+      - if @journal.has_content?(:documents) && @journal.content(:documents)&.any?
+        = render Primer::SubheadComponent.new do |component|
+          = component.heading { t :'.documents.title' }
+        %ul
+          - @journal.content(:documents).each do |document|
+            %li.list-style-none.py-1.d-flex.flex-items-center
+              = render(Primer::Beta::Text.new(tag: :div, flex: :auto)) { document.content(:name).presence ||  t(:'.documents.no_name') }
+              - if document.content(:attachment).present?
+                = render Primer::ButtonComponent.new(tag: :a, ml: 2, href: main_app.url_for(document.content(:attachment)), download: '') do
+                  = render Primer::OcticonComponent.new('desktop-download')
+                  = t :'.documents.download'
+              - else
+                = render(Primer::Beta::Text.new(tag: :div, font_size: 6, color: :muted)) { t :'.documents.no_file' }
+
+  = render 'journal_navigation'
 
 #journal-issues-list
   = render(Primer::HeadingComponent.new(tag: :h2, mt: 3)) { t '.all_issues' }
@@ -28,3 +27,8 @@
     %ul= render partial: 'issue', collection: @issues, layout: 'list_item', cached: true
   - else
     = render Primer::BlankslateComponent.new(title: t(:'.no_issues'), icon: 'mortar-board')
+
+- if @journal.has_content?(:issn) && !@journal.content(:issn).empty?
+  = render(Primer::BoxComponent.new(mt: 4)) do
+    = render(Primer::Beta::Text.new(font_weight: :bold)) do
+      = t '.issn', issn: @journal.content(:issn)

--- a/app/views/spina/conferences/primer_theme/journal/issues/index.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/index.html.haml
@@ -2,7 +2,7 @@
   = render(Primer::BoxComponent.new(display: :flex, direction: :column, flex: :auto)) do
     = render(Primer::HeadingComponent.new(tag: :h1)) { @journal.name }
     - if @journal.has_content? :description
-      = render(Primer::Markdown.new(my: 4)) { @journal.content.html(:description) }
+      = render(Primer::Markdown.new(my: 4)) { @journal.content.html(:description).to_s }
   = render(Primer::BorderBoxComponent.new(ml: [nil, nil, 4, nil], style: 'min-width: 15vw;')) do |sidebar|
     - if @journal.has_content? :logo
       - sidebar.header(bg: :primary) do

--- a/app/views/spina/conferences/primer_theme/journal/issues/index.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/index.html.haml
@@ -1,12 +1,12 @@
-= render(Primer::FlexComponent.new(direction: [:column, nil, :row, nil])) do
-  = render(Primer::FlexComponent.new(direction: :column, flex: :auto)) do
+= render(Primer::BoxComponent.new(display: :flex, direction: [:column, nil, :row, nil])) do
+  = render(Primer::BoxComponent.new(display: :flex, direction: :column, flex: :auto)) do
     = render(Primer::HeadingComponent.new(tag: :h1)) { @journal.name }
     - if @journal.has_content? :description
       = render(Primer::Markdown.new(my: 4)) { @journal.content.html(:description) }
   = render(Primer::BorderBoxComponent.new(ml: [nil, nil, 4, nil], style: 'min-width: 15vw;')) do |sidebar|
     - if @journal.has_content? :logo
       - sidebar.header(bg: :primary) do
-        = render(Primer::FlexItemComponent.new(mb: 4)) do
+        = render(Primer::BoxComponent.new(mb: 4)) do
           - cache @journal.content(:logo) do
             = image_tag main_app.url_for(@journal.content(:logo).variant(resize_to_limit: [300, 150])),
                         srcset: srcset(@journal.content(:logo), variant: { resize_to_limit: [300, 150] }),

--- a/app/views/spina/conferences/primer_theme/journal/issues/show.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/show.html.haml
@@ -1,27 +1,37 @@
 - cache [@issue, @issue.volume, @issue.articles, @issue.content(:cover_img), @issue.content(:description)] do
-  - cache [@issue, @issue.volume] do
-    = render(Primer::HeadingComponent.new(tag: :h1)) do
-      = t('spina.conferences.primer_theme.journal.volume_issue',
-          volume_number: @issue.volume.number,
-          issue_number: @issue.number)
+  = render(Primer::BoxComponent.new(display: :flex, direction: [:column, nil, nil, :row])) do
+    = render(Primer::BoxComponent.new(mr: [nil, nil, nil, 4], col: [nil, nil, nil, 8])) do
+      - cache [@issue, @issue.volume] do
+        = render(Primer::HeadingComponent.new(tag: :h1)) do
+          = t('spina.conferences.primer_theme.journal.volume_issue',
+              volume_number: @issue.volume.number,
+              issue_number: @issue.number)
 
-    - unless @issue.title.blank?
-      = render(Primer::HeadingComponent.new(tag: :h2, color: :muted, mb: 2)) { @issue.title }
+        - unless @issue.title.blank?
+          = render(Primer::HeadingComponent.new(tag: :h2, color: :muted, mb: 2)) { @issue.title }
 
-  - if @issue.has_content?(:cover_img)
-    = render partial: 'issue_cover', locals: { issue: @issue, cover_img: @issue.content(:cover_img), size: [300, 600] }
+      - if @issue.has_content?(:description)
+        = render(Primer::Markdown.new(my: 4)) do
+          = @issue.content.html(:description).to_s
 
-  - if @issue.has_content?(:description)
-    = render(Primer::Markdown.new(my: 4)) do
-      = @issue.content.html(:description).to_s
 
-  - if @issue.has_content?(:attachment)
-    = render(Primer::ButtonComponent.new(tag: :a, scheme: :primary, href: main_app.url_for(@issue.content(:attachment)), my: 2, download: '')) do
-      = render Primer::OcticonComponent.new('download')
-      = t '.download'
+      %div#journal-articles-list.border-top
+        - if @articles.any?
+          %ul= render partial: 'article', collection: @articles.sorted_asc, layout: 'list_item', cached: true
+        - else
+          = render Primer::BlankslateComponent.new(title: t(:'.no_articles'), icon: 'mortar-board')
 
-  %div#journal-articles-list.border-top
-    - if @articles.any?
-      %ul= render partial: 'article', collection: @articles.sorted_asc, layout: 'list_item', cached: true
-    - else
-      = render Primer::BlankslateComponent.new(title: t(:'.no_articles'), icon: 'mortar-board')
+    = render(Primer::BorderBoxComponent.new(ml: [nil, nil, nil, 4], col: [nil, nil, nil, 4])) do |sidebar|
+      - sidebar.body do
+        - if @issue.has_content?(:cover_img)
+          = render partial: 'spina/conferences/primer_theme/journal/issues/issue_cover', locals: { issue: @issue, cover_img: @issue.content(:cover_img), size: [300, 600] }
+        = render(Primer::BorderBoxComponent.new) do |component|
+          - component.row do
+            = render(Primer::HeadingComponent.new(tag: :h2, font_size: 4, color: :muted)) { t '.published' }
+            = render(Primer::Beta::Text.new) do
+              = time_tag @issue.date, format: :long
+          - if @issue.has_content?(:attachment)
+            - component.row do
+              = render(Primer::ButtonComponent.new(tag: :a, scheme: :primary, href: main_app.url_for(@issue.content(:attachment)), my: 2, download: '')) do
+                = render Primer::OcticonComponent.new('download')
+                = t '.download'

--- a/app/views/spina/conferences/primer_theme/journal/issues/show.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/show.html.haml
@@ -13,7 +13,7 @@
 
   - if @issue.has_content?(:description)
     = render(Primer::Markdown.new(my: 4)) do
-      = @issue.content.html(:description)
+      = @issue.content.html(:description).to_s
 
   - if @issue.has_content?(:attachment)
     = render(Primer::ButtonComponent.new(tag: :a, scheme: :primary, href: main_app.url_for(@issue.content(:attachment)), my: 2, download: '')) do

--- a/config/initializers/primer.rb
+++ b/config/initializers/primer.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-Rails.application.config.primer_view_components.silence_deprecations = true
+Rails.application.config.primer_view_components.silence_deprecations = false

--- a/config/initializers/themes/conferences_primer_theme.rb
+++ b/config/initializers/themes/conferences_primer_theme.rb
@@ -236,6 +236,11 @@
     description: 'Contains general information',
     parts: %w[text]
   }, {
+    name: 'journal_information',
+    title: 'Information (Journal)',
+    description: 'An information page specifically for the journal section',
+    parts: %w[text]
+  }, {
     name: 'committee',
     title: 'Committee',
     description: 'Contains committee bios',
@@ -286,8 +291,13 @@
   }, {
     name: 'footer',
     label: 'Footer'
-  }, {
-    name: 'journal'
+  }]
+
+  theme.resources = [{
+    name: 'journal',
+    label: 'Journal',
+    slug: 'journal',
+    view_template: 'journal_information'
   }]
 
   theme.plugins = %w[conferences journal conferences-blog]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,34 +1,3 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t(:'hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
   layouts:
     spina:
@@ -101,6 +70,8 @@ en:
       cookies_footer:
         cookies: About cookies
         loading: Loading…
+      journal_navigation:
+        issues: View all issues
 
     conferences:
       primer_theme:
@@ -175,6 +146,12 @@ en:
               logo: Journal logo
               all_issues: All Issues
               latest_issue: "Latest Issue (Vol. %{volume_number} Issue %{issue_number})"
+              issn: "ISSN: %{issn}"
+              documents:
+                title: Useful documents
+                download: Download
+                no_file: No file uploaded.
+                no_name: No name.
             show:
               no_articles: This issue has no articles.
               download: Full Issue PDF

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,7 +71,8 @@ en:
         cookies: About cookies
         loading: Loading…
       journal_navigation:
-        issues: View all issues
+        issues: View issues
+        authors: View authors
 
     conferences:
       primer_theme:
@@ -168,6 +169,16 @@ en:
               issue: Issue
               draft: THIS ARTICLE IS A DRAFT
               licence_logo: Licence logo
+          authors:
+            index:
+              authors: Authors
+              no_authors: This journal has no authors.
+            show:
+              authors: Authors
+              articles: Articles
+              aka: "Also known as:"
+              name_institution: "%{name} (%{institution})"
+
         blog:
           posts:
             index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,6 +162,7 @@ en:
               download: PDF
               doi: DOI
               url: URL
+              permalink: Permalink
               abstract: Abstract
               published: Published
               issue: Issue

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Spina::Engine.routes.draw do
         resources :articles, only: %i[show], param: :number
       end
     end
+    resources :authors, only: %i[index show]
   end
 
   namespace :frontend, as: 'frontend_blog', path: 'blog', module: 'conferences/primer_theme/blog' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,8 +10,11 @@ Spina::Engine.routes.draw do
   end
 
   namespace :frontend, path: 'journal', module: 'conferences/primer_theme/journal' do
-    resources :issues, only: %i[index show] do
-      resources :articles, only: %i[show]
+    resources :issues, only: :index
+    resources :volumes, only: [], param: :number do
+      resources :issues, only: :show, param: :number do
+        resources :articles, only: %i[show], param: :number
+      end
     end
   end
 

--- a/lib/spina/conferences/primer_theme/engine.rb
+++ b/lib/spina/conferences/primer_theme/engine.rb
@@ -9,12 +9,12 @@ module Spina
           app.config.importmap.cache_sweepers << Engine.root.join('app/assets/javascripts')
         end
 
-        config.after_initialize do
-          Spina::Part.register(Spina::Parts::Conferences::PrimerTheme::Checkbox)
-        end
-
         config.to_prepare do
           ::Spina::PagesController.helper 'spina/conferences/primer_theme/application'
+        end
+
+        config.after_initialize do
+          Spina::Part.register(Spina::Parts::Conferences::PrimerTheme::Checkbox)
         end
       end
     end

--- a/lib/spina/conferences/primer_theme/version.rb
+++ b/lib/spina/conferences/primer_theme/version.rb
@@ -3,7 +3,7 @@
 module Spina
   module Conferences
     module PrimerTheme
-      VERSION = '1.0.0.rc1'
+      VERSION = '1.0.0.rc2'
     end
   end
 end

--- a/test/controllers/spina/conferences/primer_theme/journal/articles_controller_test.rb
+++ b/test/controllers/spina/conferences/primer_theme/journal/articles_controller_test.rb
@@ -15,29 +15,29 @@ module Spina
           end
 
           test 'should get show' do
-            get frontend_issue_article_url(@article.issue, @article)
+            get frontend_volume_issue_article_url(@article.issue.volume.number, @article.issue.number, @article.number)
             assert_response :success
           end
 
           test 'should not get show for invisible article' do
-            get frontend_issue_article_url(@draft_article.issue, @draft_article)
+            get frontend_volume_issue_article_url(@draft_article.issue.volume.number, @draft_article.issue.number, @draft_article.number)
             assert_response :missing
           end
 
           test 'should get show for invisible article if authenticated' do
             @user = spina_users :joe
             post admin_sessions_url, params: { email: @user.email, password: 'password' }
-            get frontend_issue_article_url(@draft_article.issue, @draft_article)
+            get frontend_volume_issue_article_url(@draft_article.issue.volume.number, @draft_article.issue.number, @draft_article.number)
             assert_response :success
           end
 
           test 'should handle nonexistent article' do
-            get frontend_issue_article_url(@article.issue, Spina::Admin::Journal::Article.last.id + 1)
+            get frontend_volume_issue_article_url(@article.issue.volume.number, @article.issue.number, Spina::Admin::Journal::Article.last.number + 1)
             assert_response :missing
           end
 
           test 'should handle nonexistent issue' do
-            get frontend_issue_article_url(Spina::Admin::Journal::Issue.last.id + 1, @article)
+            get frontend_volume_issue_article_url(@article.issue.volume.number, Spina::Admin::Journal::Issue.last.number + 1, @article.number)
             assert_response :missing
           end
         end

--- a/test/controllers/spina/conferences/primer_theme/journal/articles_controller_test.rb
+++ b/test/controllers/spina/conferences/primer_theme/journal/articles_controller_test.rb
@@ -20,24 +20,28 @@ module Spina
           end
 
           test 'should not get show for invisible article' do
-            get frontend_volume_issue_article_url(@draft_article.issue.volume.number, @draft_article.issue.number, @draft_article.number)
+            get frontend_volume_issue_article_url(@draft_article.issue.volume.number, @draft_article.issue.number,
+                                                  @draft_article.number)
             assert_response :missing
           end
 
           test 'should get show for invisible article if authenticated' do
             @user = spina_users :joe
             post admin_sessions_url, params: { email: @user.email, password: 'password' }
-            get frontend_volume_issue_article_url(@draft_article.issue.volume.number, @draft_article.issue.number, @draft_article.number)
+            get frontend_volume_issue_article_url(@draft_article.issue.volume.number, @draft_article.issue.number,
+                                                  @draft_article.number)
             assert_response :success
           end
 
           test 'should handle nonexistent article' do
-            get frontend_volume_issue_article_url(@article.issue.volume.number, @article.issue.number, Spina::Admin::Journal::Article.last.number + 1)
+            get frontend_volume_issue_article_url(@article.issue.volume.number, @article.issue.number,
+                                                  Spina::Admin::Journal::Article.last.number + 1)
             assert_response :missing
           end
 
           test 'should handle nonexistent issue' do
-            get frontend_volume_issue_article_url(@article.issue.volume.number, Spina::Admin::Journal::Issue.last.number + 1, @article.number)
+            get frontend_volume_issue_article_url(@article.issue.volume.number,
+                                                  Spina::Admin::Journal::Issue.last.number + 1, @article.number)
             assert_response :missing
           end
         end

--- a/test/controllers/spina/conferences/primer_theme/journal/authors_controller_test.rb
+++ b/test/controllers/spina/conferences/primer_theme/journal/authors_controller_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Spina
+  module Conferences
+    module PrimerTheme
+      module Journal
+        class AuthorsControllerTest < ActionDispatch::IntegrationTest
+          include ::Spina::Engine.routes.url_helpers
+
+          setup do
+            @author = spina_admin_journal_authors :henry
+            @author_with_multiple_affiliations = spina_admin_journal_authors :marcus
+          end
+
+          test 'should get index' do
+            get frontend_authors_url
+            assert_response :success
+          end
+
+          test 'should get show' do
+            get frontend_author_url(@author)
+            assert_response :success
+          end
+
+          test 'should get show for author with multiple affiliations' do
+            get frontend_author_url(@author_with_multiple_affiliations)
+            assert_response :success
+          end
+
+          test 'should handle missing author' do
+            get frontend_author_url(Spina::Admin::Journal::Author.last.id + 1)
+            assert_response :missing
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/spina/conferences/primer_theme/journal/issues_controller_test.rb
+++ b/test/controllers/spina/conferences/primer_theme/journal/issues_controller_test.rb
@@ -19,12 +19,12 @@ module Spina
           end
 
           test 'should get show' do
-            get frontend_issue_url(@issue)
+            get frontend_volume_issue_url(@issue.volume.number, @issue.number)
             assert_response :success
           end
 
           test 'should handle missing issue' do
-            get frontend_issue_url(Spina::Admin::Journal::Issue.last.id + 1)
+            get frontend_volume_issue_url(@issue.volume.number, Spina::Admin::Journal::Issue.last.number + 1)
             assert_response :missing
           end
         end

--- a/test/integration/spina/conferences/primer_theme/journal/issues_navigation_test.rb
+++ b/test/integration/spina/conferences/primer_theme/journal/issues_navigation_test.rb
@@ -77,7 +77,7 @@ module Spina
 
           test 'view an issue' do
             issue = spina_admin_journal_issues(:vol1_issue1)
-            get frontend_issue_path(issue)
+            get frontend_volume_issue_path(issue.volume.number, issue.number)
             assert_response :success
             assert_select 'main' do
               assert_select 'h1', text: I18n.t('spina.conferences.primer_theme.journal.volume_issue',


### PR DESCRIPTION
This PR contains the following additions:
- [x] Replace uses of deprecated Primer view components
- [x] Adds a journal-specific navigation
- [x] Changes the layout of the journal section
- [x] Adds a controller for authors